### PR TITLE
Add QuoteComparison screen and navigation

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -3,18 +3,35 @@ import React, { useState } from 'react';
 import { View, StyleSheet, Text, SafeAreaView } from 'react-native';
 import HomePage from './HomePage';
 import ChatFlowRouter from './ChatFlowRouter';
+import QuoteComparison from './QuoteComparison';
 import { SUPABASE_URL } from './config';
 console.log('🧪 SUPABASE_URL:', SUPABASE_URL);
 export default function App() {
   const [screen, setScreen] = useState('home');
+  const [selectedJobId, setSelectedJobId] = useState(null);
 
   // Simple fallback if a screen fails to render
   const renderScreen = () => {
     try {
       if (screen === 'home') {
-        return <HomePage onStartNewRequest={() => setScreen('chat')} />;
-      } else {
+        return (
+          <HomePage
+            onStartNewRequest={() => setScreen('chat')}
+            onSelectJob={(id) => {
+              setSelectedJobId(id);
+              setScreen('quotes');
+            }}
+          />
+        );
+      } else if (screen === 'chat') {
         return <ChatFlowRouter onBackToHome={() => setScreen('home')} />;
+      } else {
+        return (
+          <QuoteComparison
+            logId={selectedJobId}
+            onBack={() => setScreen('home')}
+          />
+        );
       }
     } catch (err) {
       console.error('Error rendering screen:', err);

--- a/mobile/HomePage.js
+++ b/mobile/HomePage.js
@@ -1,12 +1,12 @@
 // HomePage.js
 import React, { useEffect, useState } from 'react';
-import { View, Text, Button, FlatList, StyleSheet, ActivityIndicator } from 'react-native';
+import { View, Text, Button, FlatList, StyleSheet, ActivityIndicator, TouchableOpacity } from 'react-native';
 import Constants from 'expo-constants';
 import { OPENAI_API_KEY } from './config';
 import { supabase } from './supabase';
 
 
-export default function HomePage({ onStartNewRequest }) {
+export default function HomePage({ onStartNewRequest, onSelectJob }) {
   const [jobs, setJobs] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -37,13 +37,15 @@ export default function HomePage({ onStartNewRequest }) {
   }, []);
 
   const renderItem = ({ item }) => (
-    <View style={styles.jobCard}>
-      <Text style={styles.summary}>
-        Summary: {item.assistant_reply || 'No summary'}
-      </Text>
-      <Text>Category: {item.category || 'N/A'}</Text>
-      <Text>Created: {item.created_at ? new Date(item.created_at).toLocaleString() : 'Unknown'}</Text>
-    </View>
+    <TouchableOpacity onPress={() => onSelectJob && onSelectJob(item.id)}>
+      <View style={styles.jobCard}>
+        <Text style={styles.summary}>
+          Summary: {item.assistant_reply || 'No summary'}
+        </Text>
+        <Text>Category: {item.category || 'N/A'}</Text>
+        <Text>Created: {item.created_at ? new Date(item.created_at).toLocaleString() : 'Unknown'}</Text>
+      </View>
+    </TouchableOpacity>
   );
 
   return (

--- a/mobile/QuoteComparison.js
+++ b/mobile/QuoteComparison.js
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, FlatList, ActivityIndicator, StyleSheet, Button } from 'react-native';
+import { supabase } from './supabase';
+
+export default function QuoteComparison({ logId, onBack }) {
+  const [quotes, setQuotes] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchQuotes = async () => {
+      const { data, error } = await supabase
+        .from('quotes')
+        .select('*')
+        .eq('log_id', logId)
+        .order('created_at', { ascending: true });
+
+      if (error) {
+        console.error('❌ Error fetching quotes:', error.message);
+        setError(error.message);
+      } else {
+        setQuotes(data || []);
+      }
+      setLoading(false);
+    };
+
+    fetchQuotes();
+  }, [logId]);
+
+  const renderItem = ({ item }) => (
+    <View style={styles.card}>
+      <Text style={styles.vendor}>{item.vendor_email || 'Unknown Vendor'}</Text>
+      <Text style={styles.quote}>${parseFloat(item.quote).toFixed(2)}</Text>
+      <Text style={styles.availability}>
+        Available: {item.availability ? new Date(item.availability).toLocaleString() : 'N/A'}
+      </Text>
+      <Text>Status: {item.status || 'submitted'}</Text>
+    </View>
+  );
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.header}>Quote Comparison</Text>
+      <Button title="⬅️ Back" onPress={onBack} />
+      {loading ? (
+        <ActivityIndicator size="large" color="#007AFF" style={{ marginTop: 20 }} />
+      ) : error ? (
+        <Text style={styles.error}>Error: {error}</Text>
+      ) : quotes.length === 0 ? (
+        <Text style={styles.empty}>No quotes available for this request yet.</Text>
+      ) : (
+        <FlatList
+          data={quotes}
+          keyExtractor={(item, index) => item.id?.toString() || index.toString()}
+          renderItem={renderItem}
+          contentContainerStyle={{ paddingBottom: 20 }}
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 20 },
+  header: { fontSize: 24, fontWeight: 'bold', marginBottom: 10 },
+  card: {
+    padding: 12,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 6,
+    marginVertical: 6,
+    backgroundColor: '#F9F9F9'
+  },
+  vendor: { fontWeight: 'bold', marginBottom: 4 },
+  quote: { fontSize: 18, marginBottom: 4 },
+  availability: { color: '#555', marginBottom: 4 },
+  error: { color: 'red', marginTop: 20 },
+  empty: { marginTop: 20, fontStyle: 'italic', color: '#666' }
+});


### PR DESCRIPTION
## Summary
- create `QuoteComparison.js` for viewing quotes for a job
- link HomePage list items to QuoteComparison via touchable cards
- update App navigation to handle QuoteComparison screen

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685af128aab48331bb31700a76859df7