### PR TITLE
Add expo push notification setup

### DIFF
--- a/mobile/app.config.js
+++ b/mobile/app.config.js
@@ -10,6 +10,10 @@ export default {
     platforms: ['ios', 'android', 'web'],
     orientation: 'portrait',
     backgroundColor: '#ffffff',
+    plugins: ['expo-notifications'],
+    android: {
+      useNextNotificationsApi: true
+    },
     updates: {
       fallbackToCacheTimeout: 0
     },

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -20,6 +20,8 @@
     "expo": "^53.0.0",
     "expo-constants": "~17.1.6",
     "expo-image-picker": "~16.1.4",
+    "expo-notifications": "~0.24.0",
+    "expo-server-sdk": "^4.0.0",
     "express": "^5.1.0",
     "openai": "^5.7.0",
     "react": "19.0.0",


### PR DESCRIPTION
## Summary
- configure expo-notifications in `app.config.js`
- register device push token on the client in `HomePage`
- store tokens and send push notifications on new Supabase quote inserts
- include expo-notifications and expo-server-sdk dependencies

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685af1e7b70c8331956490dc91bbdd8a