### PR TITLE
Add theme context with settings toggle

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -4,11 +4,15 @@ import { View, StyleSheet, Text, SafeAreaView } from 'react-native';
 import HomePage from './HomePage';
 import ChatFlowRouter from './ChatFlowRouter';
 import QuoteComparison from './QuoteComparison';
+import SettingsScreen from './SettingsScreen';
 import { SUPABASE_URL } from './config';
+import { ThemeProvider, useTheme } from './ThemeContext';
 console.log('🧪 SUPABASE_URL:', SUPABASE_URL);
-export default function App() {
+
+function Main() {
   const [screen, setScreen] = useState('home');
   const [selectedJobId, setSelectedJobId] = useState(null);
+  const { theme } = useTheme();
 
   // Simple fallback if a screen fails to render
   const renderScreen = () => {
@@ -21,10 +25,13 @@ export default function App() {
               setSelectedJobId(id);
               setScreen('quotes');
             }}
+            onOpenSettings={() => setScreen('settings')}
           />
         );
       } else if (screen === 'chat') {
         return <ChatFlowRouter onBackToHome={() => setScreen('home')} />;
+      } else if (screen === 'settings') {
+        return <SettingsScreen onBack={() => setScreen('home')} />;
       } else {
         return (
           <QuoteComparison
@@ -44,7 +51,7 @@ export default function App() {
   };
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView style={[styles.container, { backgroundColor: theme.background }]}>
       {renderScreen()}
     </SafeAreaView>
   );
@@ -53,7 +60,6 @@ export default function App() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fafafa',
     paddingTop: 40
   },
   centered: {
@@ -62,3 +68,12 @@ const styles = StyleSheet.create({
     alignItems: 'center'
   }
 });
+
+export default function App() {
+  return (
+    <ThemeProvider>
+      <Main />
+    </ThemeProvider>
+  );
+}
+

--- a/mobile/ChatScreen.js
+++ b/mobile/ChatScreen.js
@@ -16,6 +16,7 @@ import {
 import * as ImagePicker from 'expo-image-picker';
 import axios from 'axios';
 import ChatRoom from './ChatRoom';
+import { useTheme } from './ThemeContext';
 const query = new URLSearchParams({
   text: text || '',
   image: image || '',
@@ -29,6 +30,8 @@ export default function ChatScreen() {
   const [sending, setSending] = useState(false);
   const [urgentChatId, setUrgentChatId] = useState(null);
   const [inUrgentChat, setInUrgentChat] = useState(false);
+  const { theme } = useTheme();
+  const styles = getStyles(theme);
 
 const sendMessage = async (text = null, image = null) => {
   if (!text && !image) return;
@@ -177,20 +180,21 @@ const sendMessage = async (text = null, image = null) => {
       <View style={styles.manualRow}>
         <Button title="🚨 Get Help Now" onPress={handleGetHelpNow} disabled={sending} />
       </View>
-      {sending && <ActivityIndicator style={{ marginTop: 10 }} size="small" color="#007AFF" />}
+      {sending && <ActivityIndicator style={{ marginTop: 10 }} size="small" color={theme.primary} />}
     </KeyboardAvoidingView>
   );
 }
 
-const styles = StyleSheet.create({
-  container: { flex: 1, padding: 10, paddingTop: 50 },
-  message: { padding: 10, marginVertical: 5, borderRadius: 8, maxWidth: '80%' },
-  user: { alignSelf: 'flex-end', backgroundColor: '#DCF8C6' },
-  assistant: { alignSelf: 'flex-start', backgroundColor: '#EEE' },
-  inputRow: { flexDirection: 'row', alignItems: 'center', marginTop: 10 },
-  input: { flex: 1, borderWidth: 1, borderColor: '#ccc', borderRadius: 5, padding: 10, marginRight: 5 },
-  image: { width: 150, height: 150, borderRadius: 8 },
-  imageBtn: { marginLeft: 5, padding: 8 },
-  manualRow: { marginTop: 10 }
-});
+const getStyles = (theme) =>
+  StyleSheet.create({
+    container: { flex: 1, padding: 10, paddingTop: 50, backgroundColor: theme.background },
+    message: { padding: 10, marginVertical: 5, borderRadius: 8, maxWidth: '80%' },
+    user: { alignSelf: 'flex-end', backgroundColor: theme.card },
+    assistant: { alignSelf: 'flex-start', backgroundColor: theme.card },
+    inputRow: { flexDirection: 'row', alignItems: 'center', marginTop: 10 },
+    input: { flex: 1, borderWidth: 1, borderColor: theme.border, borderRadius: 5, padding: 10, marginRight: 5, color: theme.text },
+    image: { width: 150, height: 150, borderRadius: 8 },
+    imageBtn: { marginLeft: 5, padding: 8 },
+    manualRow: { marginTop: 10 },
+  });
 

--- a/mobile/HomePage.js
+++ b/mobile/HomePage.js
@@ -1,16 +1,19 @@
 // HomePage.js
 import React, { useEffect, useState } from 'react';
 import { View, Text, Button, FlatList, StyleSheet, ActivityIndicator, TouchableOpacity } from 'react-native';
+import { useTheme } from './ThemeContext';
 import * as Notifications from 'expo-notifications';
 import Constants from 'expo-constants';
 import { OPENAI_API_KEY } from './config';
 import { supabase } from './supabase';
 
 
-export default function HomePage({ onStartNewRequest, onSelectJob }) {
+export default function HomePage({ onStartNewRequest, onSelectJob, onOpenSettings }) {
   const [jobs, setJobs] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const { theme } = useTheme();
+  const styles = getStyles(theme);
 
   useEffect(() => {
     const registerForPush = async () => {
@@ -75,12 +78,13 @@ export default function HomePage({ onStartNewRequest, onSelectJob }) {
   );
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { backgroundColor: theme.background }]}>
       <Text style={styles.header}>🧾 Your Requests</Text>
       <Button title="➕ Start New Request" onPress={onStartNewRequest} />
+      <Button title="⚙️ Settings" onPress={onOpenSettings} />
       
       {loading ? (
-        <ActivityIndicator size="large" color="#007AFF" style={{ marginTop: 20 }} />
+        <ActivityIndicator size="large" color={theme.primary} style={{ marginTop: 20 }} />
       ) : error ? (
         <Text style={styles.error}>Error: {error}</Text>
       ) : jobs.length === 0 ? (
@@ -97,18 +101,19 @@ export default function HomePage({ onStartNewRequest, onSelectJob }) {
   );
 }
 
-const styles = StyleSheet.create({
-  container: { flex: 1, padding: 20 },
-  header: { fontSize: 24, fontWeight: 'bold', marginBottom: 10 },
-  jobCard: {
-    padding: 12,
-    borderWidth: 1,
-    borderColor: '#ccc',
-    marginVertical: 6,
-    borderRadius: 6,
-    backgroundColor: '#F9F9F9'
-  },
-  summary: { fontWeight: 'bold', marginBottom: 4 },
-  error: { color: 'red', marginTop: 20 },
-  empty: { marginTop: 20, fontStyle: 'italic', color: '#666' }
-});
+const getStyles = (theme) =>
+  StyleSheet.create({
+    container: { flex: 1, padding: 20 },
+    header: { fontSize: 24, fontWeight: 'bold', marginBottom: 10, color: theme.text },
+    jobCard: {
+      padding: 12,
+      borderWidth: 1,
+      borderColor: theme.border,
+      marginVertical: 6,
+      borderRadius: 6,
+      backgroundColor: theme.card,
+    },
+    summary: { fontWeight: 'bold', marginBottom: 4 },
+    error: { color: 'red', marginTop: 20 },
+    empty: { marginTop: 20, fontStyle: 'italic', color: theme.text },
+  });

--- a/mobile/SettingsScreen.js
+++ b/mobile/SettingsScreen.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { View, Text, Switch, StyleSheet, Appearance } from 'react-native';
+import { useTheme } from './ThemeContext';
+
+export default function SettingsScreen({ onBack }) {
+  const { theme, themeName, setThemeName } = useTheme();
+
+  const useSystem = themeName === 'system';
+  const isDark = (useSystem ? Appearance.getColorScheme() : themeName) === 'dark';
+
+  return (
+    <View style={[styles.container, { backgroundColor: theme.background }]}>
+      <Text style={[styles.header, { color: theme.text }]}>Settings</Text>
+      <View style={styles.row}>
+        <Text style={[styles.label, { color: theme.text }]}>Use System Theme</Text>
+        <Switch
+          value={useSystem}
+          onValueChange={(val) => setThemeName(val ? 'system' : 'light')}
+        />
+      </View>
+      {!useSystem && (
+        <View style={styles.row}>
+          <Text style={[styles.label, { color: theme.text }]}>Dark Mode</Text>
+          <Switch
+            value={isDark}
+            onValueChange={(val) => setThemeName(val ? 'dark' : 'light')}
+          />
+        </View>
+      )}
+      <View style={styles.row}>
+        <Text onPress={onBack} style={[styles.back, { color: theme.primary }]}>⬅️ Back</Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 20 },
+  header: { fontSize: 24, fontWeight: 'bold', marginBottom: 20 },
+  row: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginVertical: 10 },
+  label: { fontSize: 16 },
+  back: { fontSize: 16 },
+});

--- a/mobile/ThemeContext.js
+++ b/mobile/ThemeContext.js
@@ -1,0 +1,50 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { Appearance } from 'react-native';
+
+const lightTheme = {
+  background: '#FFFFFF',
+  text: '#000000',
+  card: '#F9F9F9',
+  border: '#CCCCCC',
+  primary: '#007AFF',
+};
+
+const darkTheme = {
+  background: '#000000',
+  text: '#FFFFFF',
+  card: '#1E1E1E',
+  border: '#444444',
+  primary: '#0A84FF',
+};
+
+const ThemeContext = createContext({
+  theme: lightTheme,
+  themeName: 'light',
+  setThemeName: () => {},
+});
+
+export const ThemeProvider = ({ children }) => {
+  const [systemScheme, setSystemScheme] = useState(
+    Appearance.getColorScheme() || 'light'
+  );
+  const [themeName, setThemeName] = useState('system');
+
+  useEffect(() => {
+    const listener = ({ colorScheme }) => {
+      setSystemScheme(colorScheme || 'light');
+    };
+    const sub = Appearance.addChangeListener(listener);
+    return () => sub.remove();
+  }, []);
+
+  const resolved = themeName === 'system' ? systemScheme : themeName;
+  const theme = resolved === 'dark' ? darkTheme : lightTheme;
+
+  return (
+    <ThemeContext.Provider value={{ theme, themeName, setThemeName }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);


### PR DESCRIPTION
## Summary
- introduce a `ThemeContext` with light/dark palettes
- add a new `SettingsScreen` with switches for system, light, and dark modes
- update `App` to provide theme context and route to the settings screen
- apply themed colors in `HomePage` and `ChatScreen`

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685af3419e10833184db4186c83c3574