### PR TITLE
Add vendor ratings

### DIFF
--- a/mobile/QuoteComparison.js
+++ b/mobile/QuoteComparison.js
@@ -1,11 +1,15 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, FlatList, ActivityIndicator, StyleSheet, Button } from 'react-native';
 import { supabase } from './supabase';
+import RateVendorScreen from './RateVendorScreen';
 
 export default function QuoteComparison({ logId, onBack }) {
   const [quotes, setQuotes] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [vendorRatings, setVendorRatings] = useState({});
+  const [showRating, setShowRating] = useState(false);
+  const [ratingVendor, setRatingVendor] = useState(null);
 
   useEffect(() => {
     const fetchQuotes = async () => {
@@ -27,16 +31,62 @@ export default function QuoteComparison({ logId, onBack }) {
     fetchQuotes();
   }, [logId]);
 
+  useEffect(() => {
+    const fetchRatings = async () => {
+      const unique = [...new Set(quotes.map(q => q.vendor_email))];
+      const ratingMap = {};
+      await Promise.all(
+        unique.map(async v => {
+          const { data } = await supabase
+            .from('reviews')
+            .select('rating')
+            .eq('vendor_id', v);
+          if (data && data.length > 0) {
+            const avg = data.reduce((s, r) => s + r.rating, 0) / data.length;
+            ratingMap[v] = avg.toFixed(1);
+          }
+        })
+      );
+      setVendorRatings(ratingMap);
+    };
+
+    if (quotes.length > 0) fetchRatings();
+  }, [quotes]);
+
   const renderItem = ({ item }) => (
     <View style={styles.card}>
       <Text style={styles.vendor}>{item.vendor_email || 'Unknown Vendor'}</Text>
+      <Text style={styles.rating}>
+        Rating: {vendorRatings[item.vendor_email] || 'N/A'}
+      </Text>
       <Text style={styles.quote}>${parseFloat(item.quote).toFixed(2)}</Text>
       <Text style={styles.availability}>
         Available: {item.availability ? new Date(item.availability).toLocaleString() : 'N/A'}
       </Text>
       <Text>Status: {item.status || 'submitted'}</Text>
+      {item.status === 'accepted' && (
+        <Button
+          title="Mark Completed"
+          onPress={() => {
+            supabase.from('quotes').update({ status: 'completed' }).eq('id', item.id);
+            setRatingVendor(item.vendor_email);
+            setShowRating(true);
+          }}
+        />
+      )}
     </View>
   );
+
+  if (showRating && ratingVendor) {
+    return (
+      <RateVendorScreen
+        vendorId={ratingVendor}
+        userId={null}
+        onDone={() => setShowRating(false)}
+        onSkip={() => setShowRating(false)}
+      />
+    );
+  }
 
   return (
     <View style={styles.container}>
@@ -72,6 +122,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#F9F9F9'
   },
   vendor: { fontWeight: 'bold', marginBottom: 4 },
+  rating: { marginBottom: 4 },
   quote: { fontSize: 18, marginBottom: 4 },
   availability: { color: '#555', marginBottom: 4 },
   error: { color: 'red', marginTop: 20 },

--- a/mobile/RateVendorScreen.js
+++ b/mobile/RateVendorScreen.js
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { supabase } from './supabase';
+
+export default function RateVendorScreen({ vendorId, userId, onDone, onSkip }) {
+  const [rating, setRating] = useState('');
+  const [comment, setComment] = useState('');
+
+  const handleSubmit = async () => {
+    const value = parseInt(rating, 10);
+    if (!value || value < 1 || value > 5) {
+      alert('Rating must be between 1 and 5');
+      return;
+    }
+    await supabase.from('reviews').insert({
+      vendor_id: vendorId,
+      user_id: userId,
+      rating: value,
+      comment
+    });
+    onDone && onDone();
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.header}>Rate Vendor</Text>
+      <Text>Rating (1-5)</Text>
+      <TextInput
+        style={styles.input}
+        keyboardType="numeric"
+        value={rating}
+        onChangeText={setRating}
+        placeholder="5"
+      />
+      <Text>Comment</Text>
+      <TextInput
+        style={[styles.input, { height: 80 }]}
+        multiline
+        value={comment}
+        onChangeText={setComment}
+        placeholder="Optional feedback"
+      />
+      <View style={styles.row}>
+        <Button title="Skip" onPress={onSkip} />
+        <Button title="Submit" onPress={handleSubmit} />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 20, justifyContent: 'center' },
+  header: { fontSize: 24, fontWeight: 'bold', marginBottom: 20 },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    padding: 10,
+    borderRadius: 6,
+    marginBottom: 10
+  },
+  row: { flexDirection: 'row', justifyContent: 'space-between', marginTop: 20 }
+});

--- a/mobile/VendorDashboard.js
+++ b/mobile/VendorDashboard.js
@@ -13,6 +13,7 @@ export default function VendorDashboard({ vendorLocation, radius, category, vend
   const [submittedQuotes, setSubmittedQuotes] = useState({});
   const [acceptedTicketId, setAcceptedTicketId] = useState(null);
   const [urgentTicket, setUrgentTicket] = useState(null);
+  const [rating, setRating] = useState(null);
 
   useEffect(() => {
     const fetchTickets = async () => {
@@ -44,6 +45,19 @@ export default function VendorDashboard({ vendorLocation, radius, category, vend
 
     fetchTickets();
     fetchQuotes();
+    const fetchRating = async () => {
+      const { data } = await supabase
+        .from('reviews')
+        .select('rating')
+        .eq('vendor_id', vendorEmail);
+      if (data && data.length > 0) {
+        const avg = data.reduce((s, r) => s + r.rating, 0) / data.length;
+        setRating(avg.toFixed(1));
+      } else {
+        setRating(null);
+      }
+    };
+    fetchRating();
   }, [vendorLocation, radius, category, vendorEmail]);
 
   const handleSubmitQuote = async (logId, quote, availability) => {
@@ -77,6 +91,7 @@ export default function VendorDashboard({ vendorLocation, radius, category, vend
   return (
     <div style={{ padding: 20 }}>
       <h2>Jobs in your area ({category})</h2>
+      <p><strong>Your Rating:</strong> {rating ? `${rating}/5` : 'No reviews yet'}</p>
 
       {urgentTicket && (
         <div style={{ border: '2px solid red', padding: 10, marginBottom: 20 }}>

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -1,0 +1,12 @@
+-- supabase_schema.sql
+-- Database schema for the RFQ platform.
+
+-- Reviews table stores ratings users give to vendors once a job is completed.
+create table if not exists reviews (
+    id uuid primary key default gen_random_uuid(),
+    vendor_id text not null references vendors(id),
+    user_id text references users(id),
+    rating integer not null check (rating >= 1 and rating <= 5),
+    comment text,
+    created_at timestamp with time zone default now()
+);


### PR DESCRIPTION
## Summary
- add SQL schema for reviews table
- create React Native `RateVendorScreen`
- show vendor ratings on the quote comparison screen
- include vendor's rating on their dashboard

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685af4b4375c8331b4f08a7edb7fcc48