### PR TITLE
Add status tracking for jobs

### DIFF
--- a/mobile/HomePage.js
+++ b/mobile/HomePage.js
@@ -15,6 +15,12 @@ export default function HomePage({ onStartNewRequest, onSelectJob, onOpenSetting
   const { theme } = useTheme();
   const styles = getStyles(theme);
 
+  const statusColors = {
+    open: '#FFA500',
+    quoted: '#007AFF',
+    completed: '#28A745'
+  };
+
   useEffect(() => {
     const registerForPush = async () => {
       const { status: existing } = await Notifications.getPermissionsAsync();
@@ -68,11 +74,24 @@ export default function HomePage({ onStartNewRequest, onSelectJob, onOpenSetting
   const renderItem = ({ item }) => (
     <TouchableOpacity onPress={() => onSelectJob && onSelectJob(item.id)}>
       <View style={styles.jobCard}>
+        <View
+          style={[
+            styles.statusBadge,
+            { backgroundColor: statusColors[item.status] || '#999' }
+          ]}
+        >
+          <Text style={styles.badgeText}>{item.status || 'open'}</Text>
+        </View>
         <Text style={styles.summary}>
           Summary: {item.assistant_reply || 'No summary'}
         </Text>
         <Text>Category: {item.category || 'N/A'}</Text>
-        <Text>Created: {item.created_at ? new Date(item.created_at).toLocaleString() : 'Unknown'}</Text>
+        <Text>
+          Created:{' '}
+          {item.created_at
+            ? new Date(item.created_at).toLocaleString()
+            : 'Unknown'}
+        </Text>
       </View>
     </TouchableOpacity>
   );
@@ -113,6 +132,14 @@ const getStyles = (theme) =>
       borderRadius: 6,
       backgroundColor: theme.card,
     },
+    statusBadge: {
+      alignSelf: 'flex-start',
+      paddingHorizontal: 8,
+      paddingVertical: 2,
+      borderRadius: 12,
+      marginBottom: 4,
+    },
+    badgeText: { color: '#fff', fontWeight: 'bold', fontSize: 12 },
     summary: { fontWeight: 'bold', marginBottom: 4 },
     error: { color: 'red', marginTop: 20 },
     empty: { marginTop: 20, fontStyle: 'italic', color: theme.text },

--- a/mobile/server.js
+++ b/mobile/server.js
@@ -83,7 +83,8 @@ app.get('/chat', async (req, res) => {
       assistant_reply: fullReply,
       image_url: image || null,
       user_location,
-      category
+      category,
+      status: 'open'
     }]);
 
     res.write("data: [DONE]\n\n");
@@ -145,7 +146,10 @@ app.get('/jobs-for-vendor/:vendorId', async (req, res) => {
       .select('*').eq('id', vendorId).single();
 
     const { lat: vLat, lon: vLon, radius_km, category } = vendor;
-    const { data: jobs } = await supabase.from('chat_logs').select('*');
+    const { data: jobs } = await supabase
+      .from('chat_logs')
+      .select('*')
+      .eq('status', 'open');
     const filtered = jobs.filter(job => {
       const loc = job.user_location?.coordinates;
       return loc && job.category === category &&

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -10,3 +10,15 @@ create table if not exists reviews (
     comment text,
     created_at timestamp with time zone default now()
 );
+
+-- Chat logs table stores user requests and assistant replies
+create table if not exists chat_logs (
+    id uuid primary key default gen_random_uuid(),
+    user_input text,
+    assistant_reply text,
+    image_url text,
+    user_location jsonb,
+    category text,
+    status text not null default 'open',
+    created_at timestamp with time zone default now()
+);


### PR DESCRIPTION
## Summary
- create `chat_logs` table with a new `status` field
- include `status` when inserting logs
- filter vendor job list to only open jobs
- show job status badge in the home page
- style badges

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685af776baf483319d1a3a3091fd5795