### PR TITLE
Add chat message persistence

### DIFF
--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -22,3 +22,12 @@ create table if not exists chat_logs (
     status text not null default 'open',
     created_at timestamp with time zone default now()
 );
+
+-- Chat messages table stores individual messages in a chat session
+create table if not exists chat_messages (
+    id uuid primary key default gen_random_uuid(),
+    chat_room_id uuid not null,
+    sender text not null,
+    message text,
+    created_at timestamp with time zone default now()
+);


### PR DESCRIPTION
## Summary
- add `chat_messages` table to the DB schema
- persist and reload chat history in `ChatScreen`

## Testing
- `npm test --silent` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_685b5d5e288883318e2d788b2872870f