### PR TITLE
Persist chat messages

### DIFF
--- a/mobile/ChatFlowRouter.js
+++ b/mobile/ChatFlowRouter.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
 import ChatScreen from './ChatScreen';
 import ReviewTicketScreen from './ReviewTicketScreen';
 import axios from 'axios';
@@ -8,6 +9,7 @@ export default function ChatFlowRouter({ onBackToHome }) {
   const [chatHistory, setChatHistory] = useState('');
   const [showReview, setShowReview] = useState(false);
   const [chatRoomId, setChatRoomId] = useState(null);
+  const [sessionId] = useState(uuidv4());
 
   const handleChatUpdate = (newMessages, fullTranscript) => {
     setMessages(newMessages);
@@ -72,6 +74,7 @@ export default function ChatFlowRouter({ onBackToHome }) {
       onUpdate={handleChatUpdate}
       onManualSubmit={handleManualSubmit}
       onUrgentHelp={handleUrgentDispatch}
+      sessionId={sessionId}
     />
   );
 }

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -22,3 +22,13 @@ create table if not exists chat_logs (
     status text not null default 'open',
     created_at timestamp with time zone default now()
 );
+
+-- Individual messages exchanged during a chat session
+create table if not exists chat_messages (
+    id uuid primary key default gen_random_uuid(),
+    session_id text not null,
+    role text not null,
+    type text,
+    content text,
+    created_at timestamp with time zone default now()
+);


### PR DESCRIPTION
## Summary
- create `chat_messages` table
- store chat log to Supabase in `ChatScreen`
- load existing chat messages for a session
- pass a `sessionId` from `ChatFlowRouter` into `ChatScreen`

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_685b5d5e288883318e2d788b2872870f