### PR TITLE
Implement profile About screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This project aims to build a mobile application that allows users to request quo
 7. **Progress Indicators**: Visual cues to show quote and job progress.
 8. **Favorite Vendors**: Users can bookmark preferred service providers.
 9. **Map View**: Display vendor locations and distance from the user.
+10. **About/Profile Page**: Users can enter their name and location details.
 
 ---
 This repository now includes an initial React Native scaffold located in the `mobile` directory. Future work will flesh out screens and integrate backend services to manage RFQs, quotes, and vendor management.

--- a/mobile/AboutScreen.js
+++ b/mobile/AboutScreen.js
@@ -1,0 +1,92 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import { useAuth } from './AuthContext';
+import { supabase } from './supabase';
+import { useTheme } from './ThemeContext';
+
+export default function AboutScreen({ navigation }) {
+  const { user } = useAuth();
+  const [name, setName] = useState('');
+  const [city, setCity] = useState('');
+  const [stateProv, setStateProv] = useState('');
+  const [country, setCountry] = useState('');
+  const { theme } = useTheme();
+  const styles = getStyles(theme);
+
+  useEffect(() => {
+    const loadProfile = async () => {
+      if (!user) return;
+      const { data } = await supabase
+        .from('user_profiles')
+        .select('*')
+        .eq('id', user.id)
+        .maybeSingle();
+      if (data) {
+        setName(data.full_name || '');
+        setCity(data.city || '');
+        setStateProv(data.state || '');
+        setCountry(data.country || '');
+      }
+    };
+    loadProfile();
+  }, [user]);
+
+  const handleSave = async () => {
+    if (!user) return;
+    await supabase.from('user_profiles').upsert({
+      id: user.id,
+      full_name: name,
+      city,
+      state: stateProv,
+      country,
+    });
+    alert('Profile saved');
+    navigation.goBack();
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.header}>About You</Text>
+      <TextInput
+        style={styles.input}
+        placeholder="Full Name"
+        value={name}
+        onChangeText={setName}
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="City"
+        value={city}
+        onChangeText={setCity}
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="State/Province"
+        value={stateProv}
+        onChangeText={setStateProv}
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="Country"
+        value={country}
+        onChangeText={setCountry}
+      />
+      <Button title="Save" onPress={handleSave} />
+    </View>
+  );
+}
+
+const getStyles = theme =>
+  StyleSheet.create({
+    container: { flex: 1, padding: 20, backgroundColor: theme.background },
+    header: { fontSize: 24, fontWeight: 'bold', marginBottom: 20, color: theme.text },
+    input: {
+      borderWidth: 1,
+      borderColor: theme.border,
+      borderRadius: 6,
+      padding: 10,
+      marginBottom: 10,
+      color: theme.text,
+      backgroundColor: theme.card,
+    },
+  });

--- a/mobile/App.js
+++ b/mobile/App.js
@@ -14,6 +14,7 @@ import SubmitVendorQuote from './SubmitVendorQuote';
 import VendorChatRoom from './VendorChatRoom';
 import AdminDashboardScreen from './AdminDashboardScreen';
 import SettingsScreen from './SettingsScreen';
+import AboutScreen from './AboutScreen';
 import { SUPABASE_URL } from './config';
 import { ThemeProvider, useTheme } from './ThemeContext';
 import { AuthProvider, useAuth } from './AuthContext';
@@ -25,6 +26,7 @@ const Tab = createBottomTabNavigator();
 const HomeStack = createNativeStackNavigator();
 const VendorStack = createNativeStackNavigator();
 const AuthStack = createNativeStackNavigator();
+const SettingsStack = createNativeStackNavigator();
 
 const HomePageWrapper = ({ navigation }) => (
   <HomePage
@@ -79,6 +81,19 @@ function VendorStackScreen() {
   );
 }
 
+function SettingsStackScreen() {
+  return (
+    <SettingsStack.Navigator>
+      <SettingsStack.Screen
+        name="SettingsMain"
+        component={SettingsScreen}
+        options={{ headerShown: false }}
+      />
+      <SettingsStack.Screen name="About" component={AboutScreen} />
+    </SettingsStack.Navigator>
+  );
+}
+
 function AuthStackScreen() {
   return (
     <AuthStack.Navigator>
@@ -114,7 +129,7 @@ function MainTabs() {
         <Tab.Screen name="Chat" component={ChatFlowRouter} />
         <Tab.Screen name="Vendor" component={VendorStackScreen} />
         <Tab.Screen name="Admin" component={AdminDashboardScreen} />
-        <Tab.Screen name="Settings" component={SettingsScreen} />
+        <Tab.Screen name="Settings" component={SettingsStackScreen} />
       </Tab.Navigator>
     </NavigationContainer>
   );

--- a/mobile/SettingsScreen.js
+++ b/mobile/SettingsScreen.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { View, Text, Switch, StyleSheet, Appearance } from 'react-native';
+import { View, Text, Switch, StyleSheet, Appearance, TouchableOpacity } from 'react-native';
 import { useTheme } from './ThemeContext';
 
-export default function SettingsScreen({ onBack }) {
+export default function SettingsScreen({ navigation }) {
   const { theme, themeName, setThemeName } = useTheme();
 
   const useSystem = themeName === 'system';
@@ -27,9 +27,9 @@ export default function SettingsScreen({ onBack }) {
           />
         </View>
       )}
-      <View style={styles.row}>
-        <Text onPress={onBack} style={[styles.back, { color: theme.primary }]}>⬅️ Back</Text>
-      </View>
+      <TouchableOpacity style={styles.row} onPress={() => navigation.navigate('About')}>
+        <Text style={[styles.label, { color: theme.primary }]}>About / Profile</Text>
+      </TouchableOpacity>
     </View>
   );
 }
@@ -39,5 +39,4 @@ const styles = StyleSheet.create({
   header: { fontSize: 24, fontWeight: 'bold', marginBottom: 20 },
   row: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginVertical: 10 },
   label: { fontSize: 16 },
-  back: { fontSize: 16 },
 });

--- a/mobile/ThemeContext.js
+++ b/mobile/ThemeContext.js
@@ -7,6 +7,7 @@ const lightTheme = {
   card: '#F9F9F9',
   border: '#CCCCCC',
   primary: '#007AFF',
+  secondary: '#E0E0E0',
 };
 
 const darkTheme = {
@@ -15,6 +16,7 @@ const darkTheme = {
   card: '#1E1E1E',
   border: '#444444',
   primary: '#0A84FF',
+  secondary: '#333333',
 };
 
 const ThemeContext = createContext({

--- a/mobile/__tests__/AboutScreen.test.js
+++ b/mobile/__tests__/AboutScreen.test.js
@@ -1,0 +1,7 @@
+const fs = require('fs');
+const path = require('path');
+
+test('AboutScreen file exists', () => {
+  const file = path.join(__dirname, '..', 'AboutScreen.js');
+  expect(fs.existsSync(file)).toBe(true);
+});

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -31,3 +31,13 @@ create table if not exists chat_messages (
     message text,
     created_at timestamp with time zone default now()
 );
+
+-- User profile information for storing location
+create table if not exists user_profiles (
+    id uuid primary key references users(id),
+    full_name text,
+    city text,
+    state text,
+    country text,
+    created_at timestamp with time zone default now()
+);


### PR DESCRIPTION
## Summary
- add new About screen so users can enter name and location
- hook About screen into a new Settings stack
- extend theme with a secondary color
- document About/Profile page in README
- include a simple existence test for About screen
- update schema with a `user_profiles` table

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685d7a0c77288331936ba5074ae11562