### PR TITLE
Add vendor detail screen

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -15,6 +15,7 @@ import VendorChatRoom from './VendorChatRoom';
 import AdminDashboardScreen from './AdminDashboardScreen';
 import SettingsScreen from './SettingsScreen';
 import AboutScreen from './AboutScreen';
+import VendorDetailScreen from './VendorDetailScreen';
 import { SUPABASE_URL } from './config';
 import { ThemeProvider, useTheme } from './ThemeContext';
 import { AuthProvider, useAuth } from './AuthContext';
@@ -54,6 +55,11 @@ function HomeStackScreen() {
         name="Estimate"
         component={EstimateScreen}
         options={{ title: 'Estimate' }}
+      />
+      <HomeStack.Screen
+        name="VendorDetails"
+        component={VendorDetailScreen}
+        options={{ title: 'Vendor' }}
       />
     </HomeStack.Navigator>
   );

--- a/mobile/HomePage.js
+++ b/mobile/HomePage.js
@@ -1,7 +1,8 @@
   // HomeScreen.js - Redesigned with chat history and vendor carousel
 
 import React, { useState, useEffect } from 'react';
-import { View, Text, TextInput, StyleSheet, TouchableOpacity, FlatList, ScrollView, Image, Linking } from 'react-native';
+import { View, Text, TextInput, StyleSheet, TouchableOpacity, FlatList, ScrollView, Image } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
 import FontAwesome from 'react-native-vector-icons/FontAwesome';
 import { Picker } from '@react-native-picker/picker';
 import { useTheme } from './ThemeContext';
@@ -11,6 +12,7 @@ import SkeletonList from './SkeletonList';
 
 export default function HomeScreen() {
   const { theme } = useTheme();
+  const navigation = useNavigation();
   const [category, setCategory] = useState('Plumbing');
   const [search, setSearch] = useState('');
   const [requests, setRequests] = useState([]); // historical chat
@@ -38,10 +40,6 @@ export default function HomeScreen() {
       setVendors(withRating);
     }
     setLoading(false);
-  };
-
-  const openWebsite = (url) => {
-    if (url) Linking.openURL(url);
   };
 
   return (
@@ -105,7 +103,7 @@ export default function HomeScreen() {
           {vendors.map((vendor) => (
             <TouchableOpacity
               key={vendor.id}
-              onPress={() => openWebsite(vendor.website)}
+              onPress={() => navigation.navigate('VendorDetails', { vendor })}
               style={styles.vendorCard}
             >
               {vendor.image_url ? (

--- a/mobile/VendorDetailScreen.js
+++ b/mobile/VendorDetailScreen.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import { View, Text, StyleSheet, Image, ScrollView, Button, Linking, TouchableOpacity } from 'react-native';
+import FontAwesome from 'react-native-vector-icons/FontAwesome';
+import { useTheme } from './ThemeContext';
+
+export default function VendorDetailScreen({ route, navigation }) {
+  const { vendor } = route.params || {};
+  const { theme } = useTheme();
+  const styles = getStyles(theme);
+
+  const openWebsite = () => {
+    if (vendor?.website) Linking.openURL(vendor.website);
+  };
+
+  const startChat = () => navigation.navigate('Chat');
+  const startRequest = () => navigation.navigate('Chat');
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      {vendor?.image_url ? (
+        <Image source={{ uri: vendor.image_url }} style={styles.image} />
+      ) : (
+        <View style={styles.imagePlaceholder}>
+          <Text style={{ color: '#888' }}>No Image</Text>
+        </View>
+      )}
+      <Text style={styles.name}>{vendor?.name}</Text>
+      <Text style={styles.category}>{vendor?.category}</Text>
+      <View style={styles.ratingRow}>
+        {Array.from({ length: 5 }).map((_, idx) => (
+          <FontAwesome
+            key={idx}
+            name={idx < Math.round(vendor?.average_rating || 0) ? 'star' : 'star-o'}
+            size={16}
+            color="#FFD700"
+            style={{ marginRight: 2 }}
+          />
+        ))}
+      </View>
+      {vendor?.website && (
+        <TouchableOpacity onPress={openWebsite}>
+          <Text style={styles.link}>{vendor.website}</Text>
+        </TouchableOpacity>
+      )}
+      {vendor?.email && <Text style={styles.email}>{vendor.email}</Text>}
+      <View style={styles.buttonRow}>
+        <Button title="Start Chat" onPress={startChat} />
+        <Button title="Start Request" onPress={startRequest} />
+      </View>
+    </ScrollView>
+  );
+}
+
+const getStyles = (theme) =>
+  StyleSheet.create({
+    container: { padding: 20, alignItems: 'center', backgroundColor: theme.background },
+    image: { width: 200, height: 200, borderRadius: 10, marginBottom: 10 },
+    imagePlaceholder: {
+      width: 200,
+      height: 200,
+      borderRadius: 10,
+      backgroundColor: '#eee',
+      alignItems: 'center',
+      justifyContent: 'center',
+      marginBottom: 10,
+    },
+    name: { fontSize: 24, fontWeight: 'bold', color: theme.text },
+    category: { fontSize: 16, color: '#666', marginBottom: 4 },
+    ratingRow: { flexDirection: 'row', marginBottom: 6 },
+    link: { color: theme.primary, marginBottom: 4 },
+    email: { fontSize: 14, marginBottom: 10, color: theme.text },
+    buttonRow: { flexDirection: 'row', justifyContent: 'space-around', marginTop: 20, width: '100%' },
+  });

--- a/mobile/__tests__/VendorDetailScreen.test.js
+++ b/mobile/__tests__/VendorDetailScreen.test.js
@@ -1,0 +1,7 @@
+const fs = require('fs');
+const path = require('path');
+
+test('VendorDetailScreen file exists', () => {
+  const file = path.join(__dirname, '..', 'VendorDetailScreen.js');
+  expect(fs.existsSync(file)).toBe(true);
+});


### PR DESCRIPTION
## Summary
- add a `VendorDetailScreen` to show vendor information
- navigate to it from vendor cards on the home page
- register the new screen in `App.js`
- include a basic Jest test for the new file

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685eaa83d11883318ba052b6622b74eb