### PR TITLE
Add vendor map view with location

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -21,6 +21,7 @@ import { ThemeProvider, useTheme } from './ThemeContext';
 import { AuthProvider, useAuth } from './AuthContext';
 import LoginScreen from './LoginScreen';
 import RegisterScreen from './RegisterScreen';
+import VendorMapScreen from './VendorMapScreen';
 console.log('🧪 SUPABASE_URL:', SUPABASE_URL);
 
 const Tab = createBottomTabNavigator();
@@ -60,6 +61,11 @@ function HomeStackScreen() {
         name="VendorDetails"
         component={VendorDetailScreen}
         options={{ title: 'Vendor' }}
+      />
+      <HomeStack.Screen
+        name="VendorMap"
+        component={VendorMapScreen}
+        options={{ title: 'Vendor Map' }}
       />
     </HomeStack.Navigator>
   );

--- a/mobile/HomePage.js
+++ b/mobile/HomePage.js
@@ -90,7 +90,10 @@ export default function HomeScreen() {
           <Picker.Item label="Cleaning" value="Cleaning" />
         </Picker>
 
-        <TouchableOpacity style={styles.buttonAlt}>
+        <TouchableOpacity
+          style={styles.buttonAlt}
+          onPress={() => navigation.navigate('VendorMap')}
+        >
           <Text style={styles.buttonAltText}>Find Vendors</Text>
         </TouchableOpacity>
       </View>

--- a/mobile/VendorMapScreen.js
+++ b/mobile/VendorMapScreen.js
@@ -1,0 +1,89 @@
+import React, { useState, useEffect } from 'react';
+import { View, ActivityIndicator, StyleSheet } from 'react-native';
+import MapView, { Marker } from 'react-native-maps';
+import * as Location from 'expo-location';
+import { supabase } from './supabase';
+import { useNavigation } from '@react-navigation/native';
+
+export default function VendorMapScreen() {
+  const navigation = useNavigation();
+  const [location, setLocation] = useState(null);
+  const [vendors, setVendors] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      const { status } = await Location.requestForegroundPermissionsAsync();
+      if (status !== 'granted') {
+        setLoading(false);
+        return;
+      }
+      const loc = await Location.getCurrentPositionAsync({});
+      setLocation(loc.coords);
+      fetchVendors();
+    })();
+  }, []);
+
+  const fetchVendors = async () => {
+    const { data, error } = await supabase
+      .from('vendors')
+      .select('*, reviews(rating)');
+    if (!error && data) {
+      const withRating = data.map((v) => {
+        const avg = v.reviews && v.reviews.length
+          ? v.reviews.reduce((s, r) => s + r.rating, 0) / v.reviews.length
+          : 0;
+        return { ...v, average_rating: avg };
+      });
+      setVendors(withRating);
+    }
+    setLoading(false);
+  };
+
+  if (!location || loading) {
+    return (
+      <View style={styles.centered}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  return (
+    <MapView
+      style={StyleSheet.absoluteFillObject}
+      initialRegion={{
+        latitude: location.latitude,
+        longitude: location.longitude,
+        latitudeDelta: 0.05,
+        longitudeDelta: 0.05,
+      }}
+    >
+      <Marker
+        coordinate={{ latitude: location.latitude, longitude: location.longitude }}
+        title="You are here"
+        pinColor="blue"
+      />
+      {vendors.map(
+        (v) =>
+          v.lat &&
+          v.lon && (
+            <Marker
+              key={v.id}
+              coordinate={{ latitude: v.lat, longitude: v.lon }}
+              title={v.name}
+              description={v.category}
+              onPress={() => navigation.navigate('VendorDetails', { vendor: v })}
+            />
+          )
+      )}
+    </MapView>
+  );
+}
+
+const styles = StyleSheet.create({
+  centered: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/mobile/app.config.js
+++ b/mobile/app.config.js
@@ -12,7 +12,13 @@ export default {
     backgroundColor: '#ffffff',
     plugins: ['expo-notifications'],
     android: {
-      useNextNotificationsApi: true
+      useNextNotificationsApi: true,
+      permissions: ['ACCESS_FINE_LOCATION']
+    },
+    ios: {
+      infoPlist: {
+        NSLocationWhenInUseUsageDescription: 'Allow location to find nearby vendors'
+      }
     },
     updates: {
       fallbackToCacheTimeout: 0

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -31,6 +31,7 @@
         "react-dom": "^18.2.0",
         "react-native": "0.79.4",
         "react-native-gesture-handler": "^2.12.0",
+        "react-native-maps": "^1.7.1",
         "react-native-reanimated": "^2.14.4",
         "react-native-safe-area-context": "^4.5.0",
         "react-native-screens": "^3.22.0",
@@ -3703,6 +3704,12 @@
         "@types/range-parser": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/glob": {
       "version": "7.2.0",
@@ -13098,6 +13105,28 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-maps": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.24.3.tgz",
+      "integrity": "sha512-cF5oTA8z24QqGIRFfDcsXLEs/gCd0RhaJ9KPv/2HiogKD5gpjh1naimZUJQ6IsEcUngSSk8iov6p2jd7dB+/bQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.13"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": ">= 18.3.1",
+        "react-native": ">= 0.76.0",
+        "react-native-web": ">= 0.11"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-native-reanimated": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -39,7 +39,8 @@
     "react-native-vector-icons": "^9.2.0",
     "react-native-web": "^0.18.10",
     "react-native-webview": "^13.8.4",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "react-native-maps": "^1.7.1"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",


### PR DESCRIPTION
## Summary
- add `react-native-maps` dependency
- request location permissions
- display map with vendor markers and user position
- open vendor detail from marker tap
- expose map from the home screen
- configure location permission in Expo

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685eac9b3fa0833180795cfcd68bbe54