### PR TITLE
Limit MapView to mobile

### DIFF
--- a/mobile/VendorMapScreen.js
+++ b/mobile/VendorMapScreen.js
@@ -1,6 +1,11 @@
 import React, { useState, useEffect } from 'react';
-import { View, ActivityIndicator, StyleSheet } from 'react-native';
-import MapView, { Marker } from 'react-native-maps';
+import { View, ActivityIndicator, StyleSheet, Text, Platform } from 'react-native';
+let MapView, Marker;
+if (Platform.OS !== 'web') {
+  const Maps = require('react-native-maps');
+  MapView = Maps.default;
+  Marker = Maps.Marker;
+}
 import * as Location from 'expo-location';
 import { supabase } from './supabase';
 import { useNavigation } from '@react-navigation/native';
@@ -44,6 +49,14 @@ export default function VendorMapScreen() {
     return (
       <View style={styles.centered}>
         <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  if (Platform.OS === 'web') {
+    return (
+      <View style={styles.centered}>
+        <Text>Map view is only available on mobile.</Text>
       </View>
     );
   }


### PR DESCRIPTION
## Summary
- only load `react-native-maps` on mobile platforms
- display a placeholder message when viewed on the web

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f5c87cabc833186ea07b60cc7d844